### PR TITLE
ADX-997 [OAuth2] Authorization: Bearer token confuses giftless as to which token should be used

### DIFF
--- a/giftless/auth/jwt.py
+++ b/giftless/auth/jwt.py
@@ -192,9 +192,9 @@ class JWTAuthenticator(PreAuthorizedActionAuthenticator):
     def _authenticate(self, request: Request):
         """Authenticate a request
         """
-        token = self._get_token_from_headers(request)
+        token = self._get_token_from_qs(request)
         if token is None:
-            token = self._get_token_from_qs(request)
+            token = self._get_token_from_headers(request)
         if token is None:
             return None
 


### PR DESCRIPTION
## ADX-997 [OAuth2] Authorization: Bearer token confuses giftless as to which token should be used

To access ADR resources using OAuth2 one sends Bearer token in ‘Authorization’ header.

When requesting download of a resource, one gets a redirect (HTTP 302) to giftless with a JWT access_token in a redirection URL. Unfortunately, when OAuth2 Bearer token is being used, giftless is fooled to think that Bearer token is the one to check for authorization - not the one from URL (as this is a [legitimate way to pass access token](https://giftless.datopian.com/en/latest/auth-providers.html#jwt-authenticator)). This is because usually HTTP clients have a ‘follow redirects’ set to True, and the subsequent request retains all headers of original request.

To fix this, we do a change in order of searching for access_token, so first it is sought in query string parameters - and if not found there search is done in Authorization header.

## Testing (delete if not applicable)

Added acceptance test.

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
