### PR TITLE
Adx 1001 filenames are not set correctly

### DIFF
--- a/giftless/storage/amazon_s3.py
+++ b/giftless/storage/amazon_s3.py
@@ -85,7 +85,7 @@ class AmazonS3Storage(StreamingStorage, ExternalStorage):
 
         if filename and disposition:
             filename = safe_filename(filename)
-            params['ResponseContentDisposition'] = f'attachment; filename="{filename}"'
+            params['ResponseContentDisposition'] = f'{disposition}; filename="{filename}"'
         elif disposition:
             params['ResponseContentDisposition'] = disposition
 

--- a/giftless/transfer/basic_streaming.py
+++ b/giftless/transfer/basic_streaming.py
@@ -83,11 +83,11 @@ class ObjectsView(BaseView):
 
         filename = request.args.get('filename')
         filename = safe_filename(filename)
-        disposition = request.args.get('disposition')
+        disposition = request.args.get('disposition', 'attachment')
 
         headers = {}
         if filename and disposition:
-            headers = {'Content-Disposition': f'attachment; filename="{filename}"'}
+            headers = {'Content-Disposition': f'{disposition}; filename="{filename}"'}
         elif disposition:
             headers = {'Content-Disposition': disposition}
 
@@ -159,9 +159,10 @@ class BasicStreamingTransferAdapter(PreAuthorizingTransferAdapter, ViewProvider)
             download_url = ObjectsView.get_storage_url('get', organization, repo, oid)
             preauth_url = self._preauth_url(download_url, organization, repo, actions={'read'}, oid=oid)
 
-            if extra and 'filename' in extra:
-                params = {'filename': extra['filename']}
-                preauth_url = add_query_params(preauth_url, params)
+            if extra:
+                for key in ('filename', 'disposition'):
+                    if key in extra:
+                        preauth_url = add_query_params(preauth_url, {key: extra[key]})
 
             response['actions'] = {
                 "download": {


### PR DESCRIPTION
## ADX-1001 Filenames are not set correctly for resource downloads

Here 2 things are done:
1. 'disposition' parameter passed into giftless when asking for 'download' url is encoded into resultant url in basic_streaming
2. When downloading files using basic_streaming and amazon_s3 'disposition' parameter encoded above is passed to 'Content-Disposition' header, and is set to 'attachment' if no parameter exists in request (this is the behaviour of other storages, so now it's consistent).

Change no. 1 allows opening PDF files in a web browser window (tested on Chrome and Firefox).

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
